### PR TITLE
Add comprehensive Javadoc to Java sources

### DIFF
--- a/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGenSecret.java
+++ b/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGenSecret.java
@@ -27,8 +27,20 @@ import org.springframework.extensions.webscripts.WebScriptRequest;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Web Script responsible for generating a new TOTP secret for a user and
+ * returning it together with the QR data URI needed for authenticator apps.
+ */
 public class TotpGenSecret extends TotpWebScript {
 
+    /**
+     * Generates a new TOTP secret for the requested user.
+     *
+     * @param req    current web script request
+     * @param status web script status
+     * @param cache  response cache
+     * @return model containing the generated secret and corresponding QR code URI
+     */
     protected Map<String, Object> executeImpl(
             WebScriptRequest req, Status status, Cache cache) {
 

--- a/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGetSecret.java
+++ b/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGetSecret.java
@@ -27,8 +27,20 @@ import org.springframework.extensions.webscripts.WebScriptRequest;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Web Script returning the current TOTP secret for a user together with the QR
+ * code data URI.
+ */
 public class TotpGetSecret extends TotpWebScript {
 
+    /**
+     * Retrieves the TOTP secret and QR code for the requested user.
+     *
+     * @param req    current web script request
+     * @param status web script status
+     * @param cache  response cache
+     * @return model containing the secret and QR code URI
+     */
     protected Map<String, Object> executeImpl(
             WebScriptRequest req, Status status, Cache cache) {
 

--- a/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpLoginPost.java
+++ b/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpLoginPost.java
@@ -39,7 +39,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Post based login script
+ * Web Script handling login requests that include a TOTP token in addition to
+ * the standard username and password.
  */
 public class TotpLoginPost extends org.alfresco.repo.web.scripts.bean.LoginPost {
     // dependencies
@@ -48,8 +49,14 @@ public class TotpLoginPost extends org.alfresco.repo.web.scripts.bean.LoginPost 
     @Setter
     protected EventPublisher eventPublisher;
 
-    /* (non-Javadoc)
-     * @see org.alfresco.web.scripts.DeclarativeWebScript#executeImpl(org.alfresco.web.scripts.WebScriptRequest, org.alfresco.web.scripts.WebScriptResponse)
+    /**
+     * Processes the POST request containing login credentials and delegates to
+     * {@link #login(String, String, String)} once the JSON payload has been
+     * parsed.
+     *
+     * @param req    current web script request
+     * @param status web script status
+     * @return model containing the user name and authentication ticket
      */
     @Override
     protected Map<String, Object> executeImpl(WebScriptRequest req, Status status) {
@@ -94,6 +101,15 @@ public class TotpLoginPost extends org.alfresco.repo.web.scripts.bean.LoginPost 
         }
     }
 
+    /**
+     * Performs the actual authentication using username, password and TOTP token
+     * and returns the authentication ticket.
+     *
+     * @param username user name
+     * @param password user password
+     * @param token    one-time TOTP token
+     * @return model containing the authenticated user name and ticket
+     */
     protected Map<String, Object> login(final String username, String password, String token) {
         try {
             // check totp

--- a/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpSetSecret.java
+++ b/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpSetSecret.java
@@ -30,9 +30,22 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+/**
+ * Web Script that allows administrators or users to set or clear their own TOTP
+ * secret.
+ */
 @Slf4j
 public class TotpSetSecret extends TotpWebScript {
 
+    /**
+     * Sets the supplied TOTP secret for the requested user. If the provided
+     * secret is blank, the existing secret will be cleared.
+     *
+     * @param req    current web script request
+     * @param status web script status
+     * @param cache  response cache
+     * @return model containing the updated secret and QR code URI
+     */
     protected Map<String, Object> executeImpl(
             WebScriptRequest req, Status status, Cache cache) {
 

--- a/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpWebScript.java
+++ b/alfresco-totp-authenticator-platform/src/main/java/org/saidone/alfresco/repo/web/scripts/bean/TotpWebScript.java
@@ -29,6 +29,10 @@ import org.springframework.extensions.webscripts.DeclarativeWebScript;
 import org.springframework.extensions.webscripts.WebScriptException;
 import org.springframework.extensions.webscripts.WebScriptRequest;
 
+/**
+ * Base class for TOTP related Web Scripts providing helper methods and common
+ * dependencies.
+ */
 public class TotpWebScript extends DeclarativeWebScript {
 
     @Setter
@@ -36,6 +40,14 @@ public class TotpWebScript extends DeclarativeWebScript {
     @Setter
     protected MessageService messageService;
 
+    /**
+     * Determines the target user of the web script. If no user is provided in the
+     * request, the currently authenticated user is used. Only administrators may
+     * operate on other users.
+     *
+     * @param req web script request
+     * @return user name the operation should apply to
+     */
     protected String validateUser(WebScriptRequest req) {
         var user = req.getParameter("user");
         if (Strings.isBlank(user)) {

--- a/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpAssert.java
+++ b/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpAssert.java
@@ -24,19 +24,41 @@ import lombok.AllArgsConstructor;
 import lombok.val;
 import org.junit.Assert;
 
+/**
+ * Utility assertions for verifying responses from TOTP related Web Scripts.
+ */
 public final class TotpAssert extends Assert {
 
+    /**
+     * Asserts that the standard JSON response contains a valid secret and QR code
+     * data URI.
+     *
+     * @param jsonResponse JSON string returned by the Web Script
+     */
     static void assertStandardJsonResponse(String jsonResponse) {
         val response = parseJsonResponse(jsonResponse);
         assertTrue("Secret length mismatch", (("".equals(response.secret)) || response.secret.matches("^[A-Z0-9]{32}$")));
         assertNotNull("Image data is null", response.dataUri);
     }
 
+    /**
+     * Asserts that the provided secret matches the one contained in the JSON
+     * response.
+     *
+     * @param secret       expected secret value
+     * @param jsonResponse JSON string returned by the Web Script
+     */
     static void assertSecretMatches(String secret, String jsonResponse) {
         val response = parseJsonResponse(jsonResponse);
         assertEquals(secret, response.secret);
     }
 
+    /**
+     * Parses the JSON Web Script response into a {@link Response} object.
+     *
+     * @param response JSON response string
+     * @return parsed response instance
+     */
     private static Response parseJsonResponse(String response) {
         val gson = new Gson();
         val data = (JsonObject) gson.fromJson(response, JsonObject.class).get("data");

--- a/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpBaseIT.java
+++ b/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpBaseIT.java
@@ -32,11 +32,21 @@ import org.apache.http.util.EntityUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+/**
+ * Base class providing helper methods for Web Script integration tests.
+ */
 public class TotpBaseIT {
 
     private static final String ACS_ENDPOINT_PROP = "acs.endpoint.path";
     private static final String ACS_DEFAULT_ENDPOINT = "http://localhost:8080/alfresco";
 
+    /**
+     * Executes a GET call to the given Web Script URL using basic authentication
+     * against the repository.
+     *
+     * @param url relative Web Script URL
+     * @return response body as a string
+     */
     protected String testWebScriptCall(String url) throws Exception {
         val webscriptUrl = String.format("%s%s", getPlatformEndpoint(), url);
 
@@ -60,6 +70,11 @@ public class TotpBaseIT {
         return EntityUtils.toString(entity);
     }
 
+    /**
+     * Returns the platform endpoint URL based on system properties or defaults.
+     *
+     * @return platform endpoint URL
+     */
     private String getPlatformEndpoint() {
         final String platformEndpoint = System.getProperty(ACS_ENDPOINT_PROP);
         return StringUtils.isNotBlank(platformEndpoint) ? platformEndpoint : ACS_DEFAULT_ENDPOINT;

--- a/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGenSecretIT.java
+++ b/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGenSecretIT.java
@@ -23,8 +23,14 @@ import org.junit.Test;
 
 import static org.saidone.alfresco.repo.web.scripts.bean.TotpAssert.assertStandardJsonResponse;
 
+/**
+ * Integration test for the {@code /s/security/gensecret} Web Script.
+ */
 public class TotpGenSecretIT extends TotpBaseIT {
 
+    /**
+     * Ensures that generating a new secret returns a valid JSON response.
+     */
     @Test
     public void testGenSecret() throws Exception {
         val response = testWebScriptCall("/s/security/gensecret");

--- a/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGetSecretIT.java
+++ b/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpGetSecretIT.java
@@ -23,8 +23,15 @@ import org.junit.Test;
 
 import static org.saidone.alfresco.repo.web.scripts.bean.TotpAssert.assertStandardJsonResponse;
 
+/**
+ * Integration test for the {@code /s/security/getsecret} Web Script.
+ */
 public class TotpGetSecretIT extends TotpBaseIT {
 
+    /**
+     * Ensures that the Web Script returns the expected JSON structure containing
+     * the secret and QR code data URI.
+     */
     @Test
     public void testGetSecret() throws Exception {
         val response = testWebScriptCall("/s/security/getsecret");

--- a/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpSetSecretIT.java
+++ b/alfresco-totp-authenticator-platform/src/test/java/org/saidone/alfresco/repo/web/scripts/bean/TotpSetSecretIT.java
@@ -29,9 +29,16 @@ import java.util.Locale;
 import static org.saidone.alfresco.repo.web.scripts.bean.TotpAssert.assertSecretMatches;
 import static org.saidone.alfresco.repo.web.scripts.bean.TotpAssert.assertStandardJsonResponse;
 
+/**
+ * Integration tests for the {@code /s/security/setsecret} Web Script covering
+ * various secret values.
+ */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class TotpSetSecretIT extends TotpBaseIT {
 
+    /**
+     * Ensures that providing no secret clears any existing value.
+     */
     @Order(1)
     @Test
     public void testSetEmptySecret() throws Exception {
@@ -40,6 +47,9 @@ public class TotpSetSecretIT extends TotpBaseIT {
         assertSecretMatches("", response);
     }
 
+    /**
+     * Ensures that an invalid secret does not modify the stored value.
+     */
     @Order(2)
     @Test
     public void testSetInvalidSecret() throws Exception {
@@ -48,6 +58,9 @@ public class TotpSetSecretIT extends TotpBaseIT {
         assertSecretMatches("", response);
     }
 
+    /**
+     * Verifies that a valid secret is stored correctly.
+     */
     @Order(3)
     @Test
     public void testSetValidSecret() throws Exception {
@@ -57,6 +70,10 @@ public class TotpSetSecretIT extends TotpBaseIT {
         assertSecretMatches(secret, response);
     }
 
+    /**
+     * Valid secret containing lower-case letters should be normalised to upper
+     * case.
+     */
     @Order(4)
     @Test
     public void testSetValidSecret2() throws Exception {
@@ -66,6 +83,9 @@ public class TotpSetSecretIT extends TotpBaseIT {
         assertSecretMatches(secret.toUpperCase(Locale.ROOT), response);
     }
 
+    /**
+     * Admins may set secrets for other users.
+     */
     @Order(5)
     @Test
     public void testSetValidSecret3() throws Exception {

--- a/alfresco-totp-authenticator-share/src/main/java/org/saidone/extensions/webscripts/connector/TotpAlfrescoAuthenticator.java
+++ b/alfresco-totp-authenticator-share/src/main/java/org/saidone/extensions/webscripts/connector/TotpAlfrescoAuthenticator.java
@@ -17,6 +17,11 @@ import org.springframework.extensions.webscripts.connector.RemoteClient;
 import org.springframework.extensions.webscripts.connector.Response;
 import org.springframework.extensions.webscripts.json.JSONWriter;
 
+/**
+ * {@link org.springframework.extensions.webscripts.connector.AlfrescoAuthenticator}
+ * implementation that submits the TOTP token together with the username and
+ * password when performing the login handshake.
+ */
 public class TotpAlfrescoAuthenticator extends org.springframework.extensions.webscripts.connector.AlfrescoAuthenticator {
     private static final Log logger = LogFactory.getLog(TotpAlfrescoAuthenticator.class);
 
@@ -26,6 +31,16 @@ public class TotpAlfrescoAuthenticator extends org.springframework.extensions.we
 
     public final static String CS_PARAM_ALF_TICKET = "alfTicket";
 
+    /**
+     * Performs an authentication handshake including the TOTP token if present in
+     * the credentials.
+     *
+     * @param endpoint         endpoint identifier
+     * @param credentials      user credentials, possibly containing a token
+     * @param connectorSession current connector session
+     * @return the authenticated session or {@code null} if authentication fails
+     * @throws AuthenticationException if authentication is not possible
+     */
     public ConnectorSession authenticate(String endpoint, Credentials credentials, ConnectorSession connectorSession)
             throws AuthenticationException {
         ConnectorSession cs = null;
@@ -97,6 +112,11 @@ public class TotpAlfrescoAuthenticator extends org.springframework.extensions.we
         return cs;
     }
 
+    /**
+     * Returns the login URL used to authenticate against the repository.
+     *
+     * @return login URL
+     */
     protected String getLoginURL() {
         return API_LOGIN;
     }

--- a/alfresco-totp-authenticator-share/src/main/java/org/saidone/web/site/TotpSlingshotUserFactory.java
+++ b/alfresco-totp-authenticator-share/src/main/java/org/saidone/web/site/TotpSlingshotUserFactory.java
@@ -6,12 +6,26 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.extensions.surf.support.AlfrescoUserFactory;
 import org.springframework.extensions.webscripts.connector.*;
 
+/**
+ * Extension of Alfresco's {@link org.alfresco.web.site.SlingshotUserFactory}
+ * that adds a TOTP token to the credentials used during authentication.
+ */
 public class TotpSlingshotUserFactory extends org.alfresco.web.site.SlingshotUserFactory
 {
     public static final String CREDENTIAL_TOKEN = "token";
 
     private static final Log logger = LogFactory.getLog(AlfrescoUserFactory.class);
 
+    /**
+     * Authenticates a user against the repository using username, password and
+     * the provided TOTP token.
+     *
+     * @param request  current HTTP request
+     * @param username user name
+     * @param password user password
+     * @param token    one-time TOTP token
+     * @return {@code true} if authentication succeeds, {@code false} otherwise
+     */
     public boolean authenticate(HttpServletRequest request, String username, String password, String token)
     {
         boolean authenticated = false;

--- a/alfresco-totp-authenticator-share/src/main/java/org/saidone/web/site/servlet/TotpSlingshotLoginController.java
+++ b/alfresco-totp-authenticator-share/src/main/java/org/saidone/web/site/servlet/TotpSlingshotLoginController.java
@@ -11,6 +11,10 @@ import org.springframework.extensions.surf.mvc.AbstractLoginController;
 import org.springframework.extensions.surf.site.AuthenticationUtil;
 import org.springframework.web.servlet.ModelAndView;
 
+/**
+ * Custom {@link org.alfresco.web.site.servlet.SlingshotLoginController} that adds
+ * support for a TOTP token during authentication.
+ */
 public class TotpSlingshotLoginController extends org.alfresco.web.site.servlet.SlingshotLoginController
 {
     protected static final String PARAM_TOKEN = "token";
@@ -18,16 +22,34 @@ public class TotpSlingshotLoginController extends org.alfresco.web.site.servlet.
     private TotpSlingshotUserFactory userFactory;
     private WebFrameworkConfigElement webFrameworkConfiguration;
 
+    /**
+     * Sets the user factory used to authenticate the user.
+     *
+     * @param userFactory factory capable of authenticating with a TOTP token
+     */
     public void setUserFactory(TotpSlingshotUserFactory userFactory)
     {
         this.userFactory = userFactory;
     }
 
+    /**
+     * Injects the web framework configuration.
+     *
+     * @param webFrameworkConfiguration Alfresco web framework configuration element
+     */
     public void setWebFrameworkConfiguration(WebFrameworkConfigElement webFrameworkConfiguration)
     {
         this.webFrameworkConfiguration = webFrameworkConfiguration;
     }
 
+    /**
+     * Handles the login request and performs TOTP based authentication.
+     *
+     * @param request  the HTTP request
+     * @param response the HTTP response
+     * @return always {@code null} as response handling is performed via redirects
+     * @throws Exception on authentication or IO errors
+     */
     @Override
     public ModelAndView handleRequestInternal(HttpServletRequest request, HttpServletResponse response)
             throws Exception


### PR DESCRIPTION
## Summary
- document TOTP-enabled login controller and supporting share components
- describe TOTP web scripts and service utilities with detailed Javadoc
- add integration test Javadoc for secret management web scripts

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM ...)*

------
https://chatgpt.com/codex/tasks/task_e_688dd6ddf570832f8f65196aaa2a47d0